### PR TITLE
Make textbox scrollable when text input overflows height

### DIFF
--- a/lib/chatgpt_web/components/textbox_component.ex
+++ b/lib/chatgpt_web/components/textbox_component.ex
@@ -34,7 +34,7 @@ defmodule ChatgptWeb.TextboxComponent do
     ~H"""
     <textarea
       tabindex="0"
-      style="max-height: 200px; height: 96px; overflow-y: hidden;"
+      style="max-height: 200px; height: 96px;"
       class="m-0 w-full resize-none border-0 bg-transparent p-0 pr-7 focus:ring-0 focus-visible:ring-0 dark:bg-transparent pl-2 md:pl-0"
       placeholder="Enter your message..."
       id={@field.id}


### PR DESCRIPTION
Hi. I'm wondering if you are willing to merge in this simple change.

I was playing around with the app, and whenever my text extended past the height of the textarea it would not scroll and it was impossible to edit my text prompt.

Curious to know if this was intentional?