### PR TITLE
Fixes undefined variable "self" error

### DIFF
--- a/lib/chatgpt_web/live/index.ex
+++ b/lib/chatgpt_web/live/index.ex
@@ -105,7 +105,7 @@ defmodule ChatgptWeb.IndexLive do
   def handle_error(e, state) do
     IO.puts("got error: #{inspect(e)}")
     Process.send(self(), {:set_error, "#{inspect(e)}"}, [])
-    Process.send(self, :stop_loading, [])
+    Process.send(self(), :stop_loading, [])
 
     {:noreply, state}
   end


### PR DESCRIPTION
When I tried to run mix phx.server off a fresh clone I got the following error:

```
error: undefined variable "self"
  lib/chatgpt_web/live/index.ex:108: ChatgptWeb.IndexLive.handle_error/2
```

The change here fixed the issue.